### PR TITLE
revert: use a newer unpublished version of tap_framework instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,7 @@ setup(name='tap-mavenlink',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_mavenlink'],
       install_requires=[
-          'singer-python>=5.1.0,<5.14',
-          'backoff>=1.3.2,<=1.8.0',
-          'requests>=2.18.4,<=2.31',
-          'requests-oauthlib>=0.8.0,<1.4',
-          'funcy>=1.10.1,<1.19',
-          'urllib3>=2'
+          'tap_framework @ git+https://github.com/dbt-labs/tap-framework.git'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
The latest version of tap_framework supports Python 3.10, it just isn't on pypi. Use a direct git installation.